### PR TITLE
Appdomains

### DIFF
--- a/Samples/Outlook.RelatedData/OutlookAddInOffice365Api-Debug.xml
+++ b/Samples/Outlook.RelatedData/OutlookAddInOffice365Api-Debug.xml
@@ -9,6 +9,9 @@
   <DisplayName DefaultValue="Context"/>
   <Description DefaultValue="Context Owa App"/>
   <IconUrl DefaultValue="https://localhost:8443/content/OfficeDev.png"/>
+  <AppDomains>
+    <AppDomain>https://login.microsoftonline.com</AppDomain>
+  </AppDomains>
   <Hosts>
     <Host Name="Mailbox"/>
   </Hosts>

--- a/Samples/Outlook.RelatedData/src/index.html
+++ b/Samples/Outlook.RelatedData/src/index.html
@@ -19,7 +19,7 @@
   <script src="https://appsforoffice.microsoft.com/lib/1.1/hosted/Office.debug.js" type="application/javascript"></script>
 
   <script src="https://code.highcharts.com/stock/highstock.src.js"></script>
-  <script src="/vendor/highcharts-ng/src/highcharts-ng.js"></script>
+  <script src="/vendor/highcharts-ng/dist/highcharts-ng.js"></script>
   <!-- styles -->
   <link href="/vendor/bootstrap/dist/css/bootstrap.css" rel="stylesheet" type="text/css"/>
   <link href="../content/style.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
It looks like that *https://login.microsoftonline.com* should be introduced in the appdomains of the office app. Otherwise and X-Frame will prevent the authentication flow to happen in the sandboxed iFrame containing the app.