### PR TITLE
Add login.microsoftonline.com to the app domains

### DIFF
--- a/Samples/Outlook.RelatedData/OutlookAddInOffice365Api-Debug.xml
+++ b/Samples/Outlook.RelatedData/OutlookAddInOffice365Api-Debug.xml
@@ -9,6 +9,9 @@
   <DisplayName DefaultValue="Context"/>
   <Description DefaultValue="Context Owa App"/>
   <IconUrl DefaultValue="https://localhost:8443/content/OfficeDev.png"/>
+  <AppDomains>
+    <AppDomain>https://login.microsoftonline.com</AppDomain>
+  </AppDomains>
   <Hosts>
     <Host Name="Mailbox"/>
   </Hosts>


### PR DESCRIPTION
It looks like that https://login.microsoftonline.com should be introduced in the appdomains of the office app. Otherwise and X-Frame will prevent the authentication flow to happen in the sandboxed iFrame containing the app.

Resubmission of PR #7