### PR TITLE
Server js

### DIFF
--- a/Samples/Outlook.RelatedData/server.js
+++ b/Samples/Outlook.RelatedData/server.js
@@ -25,15 +25,6 @@ app.use('/template', express.static(__dirname + '/bower_components/ui.bootstrap/
 var server = https.createServer(https_options, app)
                   .listen(PORT, HOST);
 
-
-var httpServer = http.createServer(app);
-var httpOptions = {
-	port: 80,
-	host: 'localhost'
-};
-
-httpServer.listen(httpOptions);
-
 console.log('+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+');
 console.log('HTTPS Server listening @ https://%s:%s', HOST, PORT);
 console.log('+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+');


### PR DESCRIPTION
The server.js file is used to run the node server locally. However, there are conflicts with two existing configurations within this file. Use only one, with https for protocol and localhost with given port.

Resubmission of PR #6 (and incorrect #10)