### PR TITLE
Upgrade MSAL.js to v2

### DIFF
--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
@@ -9,10 +9,10 @@ Learn how to build a Microsoft Office Add-in, as a single-page application (SPA)
 Integrating data from online service providers increases the value and adoption of your add-ins. This code sample shows you how to connect your SPA add-in to Microsoft Graph. Use this code sample to:
 
 * Connect to Microsoft Graph from an Office Add-in.
-* Use the msal.js Library to implement the OAuth 2.0 authorization framework in an add-in, using the Implicit Flow.
+* Use the MSAL.js Library to implement the OAuth 2.0 authorization framework in an add-in, using the Auth Code Flow w/ PKCE for SPAs.
 * Use the OneDrive REST APIs from Microsoft Graph.
 * Show a dialog using the Office UI namespace.
-* Build an Add-in using React, msal.js,  and Office.js. 
+* Build an Add-in using React, MSAL.js, and Office.js. 
 * Use add-in commands in an add-in.
 
 ## Applies to
@@ -47,6 +47,7 @@ Office Add-in Microsoft Graph React | Microsoft
 
 Version  | Date | Comments
 ---------| -----| --------
+1.1  | December 10th, 2020 | Upgrade MSAL.js to v2
 1.0  | August 29th, 2019| Initial release
 
 ## Disclaimer
@@ -61,11 +62,10 @@ Version  | Date | Comments
 
 1. Register your application using the [Azure Management Portal](https://manage.windowsazure.com). **Log in with the identity of an administrator of your Office 365 tenancy to ensure that you are working in an Azure Active Directory that is associated with that tenancy.** To learn how to register your application, see [Register an application with the Microsoft Identity Platform](https://docs.microsoft.com/graph/auth-register-app-v2). Use the following settings:
 
- - REDIRCT URI: `https://localhost:3000/login/login.html`
+ - REDIRCT URI: `https://localhost:3000/login/login.html` (this must be added under "Single-Page Application")
  - SUPPORTED ACCOUNT TYPES: "**Accounts in any organizational directory**"
- - IMPLICIT GRANT: Enable *both* options: **Access tokens** and **ID tokens**
  - API PERMISSIONS: none. Do not request any. 
- - SECRETS: none. The sample uses the OAuth 2.0 Implicit Flow, which requires no secrets.
+ - SECRETS: none. The sample uses the OAuth 2.0 Auth Code Flow w/ PKCE for SPAs, which requires no secrets.
 
 	> Note: After you register your application, copy the **Application (client) ID** on the **Overview** blade of the App Registration in the Azure Management Portal. 
 	 

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/login/login.ts
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/login/login.ts
@@ -3,60 +3,42 @@
  * See LICENSE in the project root for license information.
  */
 
-import * as msal from 'msal';
+import { PublicClientApplication } from "@azure/msal-browser";
 
 (() => {
   // The initialize function must be run each time a new page is loaded
   Office.initialize = () => {
 
-    const config: msal.Configuration = {
-      auth: {
-        clientId: 'fc19440a-334e-471e-af53-a1c1f53c9226',
-        authority: 'https://login.microsoftonline.com/common',
-        redirectUri: 'https://localhost:3000/login/login.html'
-      },
-      cache: {
-        cacheLocation: 'localStorage', // needed to avoid "login required" error
-        storeAuthStateInCookie: true   // recommended to avoid certain IE/Edge issues
-      }
-    };
-
-    const userAgentApp: msal.UserAgentApplication = new msal.UserAgentApplication(config);
-
-    const authCallback = (error: msal.AuthError, response: msal.AuthResponse) => {
-
-      if (!error) {
-        if (response.tokenType === 'id_token') {
-         localStorage.setItem("loggedIn", "yes");
+    const msalInstance = new PublicClientApplication({
+        auth: {
+          clientId: '0a61c279-646b-4055-a5f1-1c3da7f70f18',
+          authority: 'https://login.microsoftonline.com/common',
+          redirectUri: 'https://localhost:3000/login/login.html' // Must be registered as "spa" type
+        },
+        cache: {
+          cacheLocation: 'localStorage', // needed to avoid "login required" error
+          storeAuthStateInCookie: true   // recommended to avoid certain IE/Edge issues
         }
-        else {
-          // The tokenType is access_token, so send success message and token.
-          Office.context.ui.messageParent( JSON.stringify({ status: 'success', result : response.accessToken }) );
-        }
-      }
-      else {
-        const errorData: string = `errorMessage: ${error.errorCode}
+      });
+
+    // handleRedirectPromise should be invoked on every page load
+    msalInstance.handleRedirectPromise()
+        .then((response) => {
+            // If response is non-null, it means page is returning from AAD with a successful response
+            if (response) {
+                Office.context.ui.messageParent( JSON.stringify({ status: 'success', result : response.accessToken }) );
+            } else {
+                // Otherwise, invoke login
+                msalInstance.loginRedirect({
+                    scopes: ['user.read', 'files.read.all']
+                });
+            }
+        })
+        .catch((error) => {
+            const errorData: string = `errorMessage: ${error.errorCode}
                                    message: ${error.errorMessage}
                                    errorCode: ${error.stack}`;
-        Office.context.ui.messageParent( JSON.stringify({ status: 'failure', result: errorData }));
-      }
-    };
-
-    userAgentApp.handleRedirectCallback(authCallback);
-
-    const request: msal.AuthenticationParameters = {
-      scopes: ['user.read', 'files.read.all'],
-    };
-
-    if (localStorage.getItem("loggedIn") === "yes") {
-      userAgentApp.acquireTokenRedirect(request);
-    }
-    else {
-        // This will login the user and then the (response.tokenType === "id_token")
-        // path in authCallback below will run, which sets localStorage.loggedIn to "yes"
-        // and then the dialog is redirected back to this script, so the 
-        // acquireTokenRedirect above runs.
-        userAgentApp.loginRedirect(request);
-    }
+            Office.context.ui.messageParent( JSON.stringify({ status: 'failure', result: errorData }));
+        });
   };
 })();

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/login/login.ts
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/login/login.ts
@@ -11,7 +11,7 @@ import { PublicClientApplication } from "@azure/msal-browser";
 
     const msalInstance = new PublicClientApplication({
         auth: {
-          clientId: '0a61c279-646b-4055-a5f1-1c3da7f70f18',
+          clientId: 'fc19440a-334e-471e-af53-a1c1f53c9226',
           authority: 'https://login.microsoftonline.com/common',
           redirectUri: 'https://localhost:3000/login/login.html' // Must be registered as "spa" type
         },

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/logout/logout.ts
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/logout/logout.ts
@@ -11,7 +11,7 @@ import { PublicClientApplication } from '@azure/msal-browser';
 
     const msalInstance = new PublicClientApplication({
         auth: {
-            clientId: '0a61c279-646b-4055-a5f1-1c3da7f70f18',
+            clientId: 'fc19440a-334e-471e-af53-a1c1f53c9226',
             redirectUri: 'https://localhost:3000/logoutcomplete/logoutcomplete.html', 
             postLogoutRedirectUri: 'https://localhost:3000/logoutcomplete/logoutcomplete.html'
         }

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/logout/logout.ts
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/logout/logout.ts
@@ -3,21 +3,20 @@
  * See LICENSE in the project root for license information.
  */
 
-import * as msal from 'msal';
+import { PublicClientApplication } from '@azure/msal-browser';
 
 (() => {
   // The initialize function must be run each time a new page is loaded
   Office.initialize = () => {
 
-    const config: msal.Configuration = {
-      auth: {
-          clientId: 'fc19440a-334e-471e-af53-a1c1f53c9226',
-          redirectUri: 'https://localhost:3000/logoutcomplete/logoutcomplete.html', 
-          postLogoutRedirectUri: 'https://localhost:3000/logoutcomplete/logoutcomplete.html'
-      }
-    };
+    const msalInstance = new PublicClientApplication({
+        auth: {
+            clientId: '0a61c279-646b-4055-a5f1-1c3da7f70f18',
+            redirectUri: 'https://localhost:3000/logoutcomplete/logoutcomplete.html', 
+            postLogoutRedirectUri: 'https://localhost:3000/logoutcomplete/logoutcomplete.html'
+        }
+    });
 
-    const userAgentApplication = new msal.UserAgentApplication(config);
-    userAgentApplication.logout();
+    msalInstance.logout();
   };
 })();

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/package-lock.json
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/package-lock.json
@@ -4,6 +4,37 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@azure/msal-browser": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.8.0.tgz",
+            "integrity": "sha512-I6n7EQnwsZXgKPOLlS5X48jhzUNUFwMVm180wDBA/pwEkUy8ei6zWiPMBfWaMSxz9uNx9WHaEhgAyhJy0ze3AQ==",
+            "requires": {
+                "@azure/msal-common": "^2.0.0"
+            }
+        },
+        "@azure/msal-common": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-2.0.0.tgz",
+            "integrity": "sha512-d1RNcJb+P1EGzMHtgbZoVlHLQWjlVfr504jywNk9YEfoq8Hw3BxJ0wepu+1w0hc64D8zG0wljcvHaIH1jTn2SA==",
+            "requires": {
+                "debug": "^4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
         "@babel/code-frame": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -5012,14 +5043,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "msal": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/msal/-/msal-1.1.3.tgz",
-            "integrity": "sha512-cdShb+N1H3OyR1y46ij6OO7QzeqC6BxrbrNcouS4JBrr1+DnZ55TumxQKEzWmTXHvsbsuz5PCyXZl812Un8L9g==",
-            "requires": {
-                "tslib": "^1.9.3"
-            }
         },
         "multicast-dns": {
             "version": "6.2.3",

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/package.json
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/package.json
@@ -2,7 +2,7 @@
     "name": "office-add-in-microsoft-graph-react",
     "description": "",
     "author": "",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "scripts": {
         "clean": "rimraf dist && rimraf .awcache",
         "lint": "tslint --project tsconfig.json",
@@ -12,10 +12,10 @@
         "validate": "office-toolbox validate -m manifest.xml"
     },
     "dependencies": {
+        "@azure/msal-browser": "^2.8.0",
         "@microsoft/office-js-helpers": "^1.0.2",
         "axios": "^0.19.0",
         "core-js": "^2.6.1",
-        "msal": "^1.1.3",
         "office-ui-fabric-react": "^6.138.1",
         "react": "^16.8.1",
         "react-dom": "^16.8.1"


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                                |
| New feature?    | no                                |
| New sample?     | no                                |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |

## What's in this Pull Request?

Hello! Jason from the MSAL.js team. This PR upgrades the Office Addin MS Graph React sample to use MSAL Browser, our new library which switches from the Implicit Flow to the Auth Code Flow w/ PKCE for SPAs. One notable advantage of upgrading to MSAL Browser is that is it should mitigate [problems caused by the Edge webview truncating long URLs](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/2726). 

I have tested this with my own MSA account (my MSFT corp account needs admin permissions for the scopes used).

## Guidance

One change I cannot make myself is that the redirect URIs for `fc19440a-334e-471e-af53-a1c1f53c9226` need to be updated to the "Single Page Application" type. This type is backwards compatible with the Implicit Flow, so it would not break anyone using that client ID with the Implicit Flow (e.g. other samples, old versions of this sample).

PR template instructions to make this PR against `dev`, however, this sample does not exist in the `dev` branch. 

This sample is fantastic, thanks for putting it together!