### PR TITLE
Contextual tabs: fix issue with two task panes getting displayed

### DIFF
--- a/Samples/office-contextual-tabs/src/commands/ribbonJSON.js
+++ b/Samples/office-contextual-tabs/src/commands/ribbonJSON.js
@@ -16,8 +16,6 @@ export function getContextualRibbonJSON() {
         {
             "id": "showTaskpaneContoso",
             "type": "ShowTaskpane",
-            "sourceLocation": "https://localhost:3000/taskpane.html",
-            "taskpaneId": "ContosoMain",
             "title": "Contoso task pane",
             "supportPinning": false
           }


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                                |
| New sample?     | no                               |
| Related issues? | no |

## What's in this Pull Request?

Fixes a bug in the contextual tabs sample where if the task pane is displayed, and you select the "Show task pane" button on the "Table Data" contextual tab, you end up with the same task pane displayed twice.

With this fix it only ever shows the 1 task pane.

Solution is to not reference an id or URL location in the JSON (which sends an intent to launch a different task pane rather than default.)