### PR TITLE
Fixed invalid Manifest on failing validation

### DIFF
--- a/Samples/office-contextual-tabs/manifest.xml
+++ b/Samples/office-contextual-tabs/manifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
+  xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
   <Id>8b98e15a-7fd6-4948-b8e7-4374f0b47132</Id>
   <Version>1.0.0.0</Version>
   <ProviderName>Contoso</ProviderName>
@@ -12,14 +15,14 @@
   <AppDomains>
     <AppDomain>https://www.contoso.com</AppDomain>
   </AppDomains>
-  <Requirements>
-<Sets DefaultMinVersion="1.1">
-  <Set Name="SharedRuntime" MinVersion="1.1"/>
-</Sets>
-</Requirements>
   <Hosts>
     <Host Name="Workbook"/>
   </Hosts>
+  <Requirements>
+    <Sets DefaultMinVersion="1.1">
+      <Set Name="SharedRuntime" MinVersion="1.1"/>
+    </Sets>
+  </Requirements>
   <DefaultSettings>
     <SourceLocation DefaultValue="https://localhost:3000/taskpane.html"/>
   </DefaultSettings>
@@ -27,9 +30,9 @@
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Hosts>
       <Host xsi:type="Workbook">
-      <Runtimes>
-      <Runtime resid="Taskpane.Url" lifetime="long" />
-    </Runtimes>
+        <Runtimes>
+          <Runtime resid="Taskpane.Url" lifetime="long" />
+        </Runtimes>
         <DesktopFormFactor>
           <GetStarted>
             <Title resid="GetStarted.Title"/>

--- a/Samples/office-contextual-tabs/package-lock.json
+++ b/Samples/office-contextual-tabs/package-lock.json
@@ -1896,6 +1896,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4062,6 +4072,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6103,6 +6120,13 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6533,26 +6557,36 @@
       }
     },
     "office-addin-manifest": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.5.7.tgz",
-      "integrity": "sha512-oQZ5O4qZs6S2kZRkgQEoj/dt7KbdibslUDEcvpYA4CZIyS1pjszJMIuwUJC/mcD+z+uKGXYK9VsEhCVqATs0IA==",
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.5.16.tgz",
+      "integrity": "sha512-s9T/2oHEYAkosuns143THGyDyoxcpgRowrkRF4qQJFqYjU2ruklQw+FujmsFLmOxvGGcgXrk6XeoEwR3vD3QAw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
-        "commander": "^2.20.3",
+        "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.0.13",
-        "office-addin-usage-data": "^1.1.7",
+        "office-addin-cli": "^1.0.17",
+        "office-addin-usage-data": "^1.0.23",
         "path": "^0.12.7",
         "uuid": "^3.4.0",
         "xml2js": "^0.4.23"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
+        },
+        "office-addin-cli": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.17.tgz",
+          "integrity": "sha512-Q8ldxcxPF69/W4TprG9u3M2zFigQR/bTF3CJDb/BQPgMIMZIOSHhOd1jUNDCufEhwm8uhuywIOhxbemahweFoQ==",
+          "dev": true,
+          "requires": {
+            "commander": "^6.2.0",
+            "node-fetch": "^2.6.1"
+          }
         }
       }
     },
@@ -9041,7 +9075,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "is-binary-path": {
           "version": "1.0.1",
@@ -9555,7 +9593,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "is-binary-path": {
           "version": "1.0.1",

--- a/Samples/office-contextual-tabs/package.json
+++ b/Samples/office-contextual-tabs/package.json
@@ -46,7 +46,7 @@
     "office-addin-debugging": "^3.0.34",
     "office-addin-dev-certs": "^1.5.5",
     "office-addin-lint": "^1.0.26",
-    "office-addin-manifest": "1.5.7",
+    "office-addin-manifest": "^1.5.16",
     "office-addin-prettier-config": "^1.0.12",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.2.2",


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | no |

## What's in this Pull Request?

Manifest Validation Failed due to misplaced Hosts section

Moved Hosts section to under AppDomains
Also upped the office-addin-manifest to the latest package for the latest validator (solving the failing validation on localhost urls)

## Guidance

No additional guidance needed. 

To repro run:
npm run validate 
before and after the change
