### PR TITLE
Add try catch for inserting external Excel files

### DIFF
--- a/Samples/excel-insert-file/index.js
+++ b/Samples/excel-insert-file/index.js
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-const dataSourceUrl = "https://officedev.github.io/PnP-OfficeAddins/Samples/excel-insert-file";
+const dataSourceUrl =
+  "https://officedev.github.io/PnP-OfficeAddins/Samples/excel-insert-file";
 
 Office.onReady((info) => {
   if (info.host === Office.HostType.Excel) {
@@ -16,56 +17,70 @@ async function insertSheets() {
 
   reader.onload = async (event) => {
     Excel.run(async (context) => {
-      // Remove the metadata before the base64-encoded string.
-      const startIndex = reader.result.toString().indexOf("base64,");
+      try {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
 
-      // 7 is the length of the "base64," string to skip past
-      const workbookContents = reader.result.toString().substr(startIndex + 7);
+        // 7 is the length of the "base64," string to skip past
+        const workbookContents = reader.result
+          .toString()
+          .substr(startIndex + 7);
 
-      // STEP 1: Insert the template into the workbook.
-      const workbook = context.workbook;
+        // STEP 1: Insert the template into the workbook.
+        const workbook = context.workbook;
 
-      // Set up the insert options.
-      var options = {
-        sheetNamesToInsert: ["Template"], // Insert the "Template" worksheet from the source workbook.
-        positionType: Excel.WorksheetPositionType.after, // Insert after the `relativeTo` sheet.
-        relativeTo: "Sheet1",
-      }; // The sheet relative to which the other worksheets will be inserted. Used with `positionType`.
+        // Set up the insert options.
+        var options = {
+          sheetNamesToInsert: ["Template"], // Insert the "Template" worksheet from the source workbook.
+          positionType: Excel.WorksheetPositionType.after, // Insert after the `relativeTo` sheet.
+          relativeTo: "Sheet1",
+        }; // The sheet relative to which the other worksheets will be inserted. Used with `positionType`.
 
-      // Insert the external worksheet.
-      workbook.insertWorksheetsFromBase64(workbookContents, options);
-      await context.sync();
+        // Insert the external worksheet.
+        workbook.insertWorksheetsFromBase64(workbookContents, options);
 
-      // STEP 2: Add data from the "Service".
-      const sheet = context.workbook.worksheets.getItem("Template");
+        // In Excel on the web, if the worksheet being inserted contains unsupported features,
+        // such as Comment, Slicer, Chart, and PivotTable, insertWorksheetsFromBase64 will fail.
+        // In your production add-in, you should notify the user in the add-ins UI.
+        // As a workaround they can use Excel on desktop, or choose a different worksheet.
+        await context.sync();
 
-      // Get data from your REST API. For this sample, the JSON is fetched from a file in the repo.
-      let response = await fetch(dataSourceUrl + "/data.json");
-      if (response.ok) {
-        var json = await response.json();
-      } else {
-        console.error("HTTP-Error: " + response.status);
+        // STEP 2: Add data from the "Service".
+        const sheet = context.workbook.worksheets.getItem("Template");
+
+        // Get data from your REST API. For this sample, the JSON is fetched from a file in the repo.
+        let response = await fetch(dataSourceUrl + "/data.json");
+        if (response.ok) {
+          var json = await response.json();
+        } else {
+          console.error("HTTP-Error: " + response.status);
+        }
+
+        // Map JSON to table columns.
+        const newSalesData = json.salesData.map((item) => [
+          item.PRODUCT,
+          item.QTR1,
+          item.QTR2,
+          item.QTR3,
+          item.QTR4,
+        ]);
+
+        // We know that the table in this template starts at B5, so we start with that.
+        // Next, we calculate the total number of rows from our sales data.
+        const startRow = 5;
+        var address =
+          "B" + startRow + ":F" + (newSalesData.length + startRow - 1);
+
+        // Write the sales data to the table in the template.
+        var range = sheet.getRange(address);
+        range.values = newSalesData;
+        sheet.activate();
+        return context.sync();
+      } catch (error) {
+        // In your production add-in, you should notify the user in the add-in UI.
+        console.error(error);
+        return;
       }
-
-      // Map JSON to table columns.
-      const newSalesData = json.salesData.map((item) => [
-        item.PRODUCT,
-        item.QTR1,
-        item.QTR2,
-        item.QTR3,
-        item.QTR4
-      ]);
-
-      // We know that the table in this template starts at B5, so we start with that.
-      // Next, we calculate the total number of rows from our sales data.
-      const startRow = 5;
-      var address = "B" + startRow + ":F" + (newSalesData.length + startRow - 1);
-
-      // Write the sales data to the table in the template.
-      var range = sheet.getRange(address);
-      range.values = newSalesData;
-      sheet.activate();
-      return context.sync();
     });
   };
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                                |
| Related issues? | no  |

## What's in this Pull Request?

Adds a try...catch block. An error can occur when inserting worksheets in Excel on the web. If a worksheet has unsupported features, such as charts, the insertWorksheetsFromBase64 method will fail. Added code comments on how to work with this.