### PR TITLE
add consistent short urls for code gallery

### DIFF
--- a/Samples/Excel.OfflineStorageAddin/README.md
+++ b/Samples/Excel.OfflineStorageAddin/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-access-data-offline
 products:
 - office-excel
 - office-365

--- a/Samples/VSTO-shared-code-migration/README.md
+++ b/Samples/VSTO-shared-code-migration/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-migrate-vsto-to-web
 products:
 - office
 - office-excel

--- a/Samples/auth/Office-Add-in-ASPNET-SSO/README.md
+++ b/Samples/auth/Office-Add-in-ASPNET-SSO/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-sso-aspnet
 products:
 - office-excel
 - office-powerpoint

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-auth-aspnet-graph
 products:
 - office-excel
 - office-365

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
@@ -1,6 +1,6 @@
 ---
 page_type: sample
-urlFragment: office-add-in-auth-nodejs-graph
+urlFragment: office-add-in-auth-graph-react
 products:
 - office-excel
 - office-powerpoint

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
@@ -1,3 +1,23 @@
+---
+page_type: sample
+urlFragment: office-add-in-auth-nodejs-graph
+products:
+- office-excel
+- office-powerpoint
+- office-word
+- microsoft-365
+languages:
+- javascript
+extensions:
+  contentType: samples
+  technologies:
+  - Add-ins
+  - Microsoft Graph
+  services:
+  - Excel
+  - Microsoft 365
+  createdDate: 5/1/2017 2:09:09 PM
+---
 # Get OneDrive data using Microsoft Graph and msal.js in an Office Add-in 
 
 ## Summary

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/README.md
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/README.md
@@ -1,6 +1,6 @@
 ---
 page_type: sample
-urlFragment: office-add-in-nodejs-sso
+urlFragment: office-add-in-sso-nodejs
 products:
 - office-excel
 - office-powerpoint

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: outlook-add-in-auth-aspnet-graph
 products:
 - office-outlook
 - office-365

--- a/Samples/auth/Outlook-Add-in-SSO/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: outlook-add-in-sso-aspnet
 products:
 - office
 - office-outlook

--- a/Samples/excel-insert-file/README.md
+++ b/Samples/excel-insert-file/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: excel-add-in-insert-external-file
 products:
 - office-excel
 - office

--- a/Samples/excel-keyboard-shortcuts/README.md
+++ b/Samples/excel-keyboard-shortcuts/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-keyboard-shortcuts
 products:
 - office-excel
 - office

--- a/Samples/excel-shared-runtime-global-state/README.md
+++ b/Samples/excel-shared-runtime-global-state/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-shared-runtime-global-data
 products:
 - office-excel
 - office-365

--- a/Samples/excel-shared-runtime-scenario/README.md
+++ b/Samples/excel-shared-runtime-scenario/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-ribbon-task-pane-ui
 products:
 - office-excel
 - office-365

--- a/Samples/office-contextual-tabs/README.md
+++ b/Samples/office-contextual-tabs/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: office-add-in-contextual-tabs
 products:
 - office-excel
 - office-powerpoint

--- a/Samples/outlook-set-signature/README.md
+++ b/Samples/outlook-set-signature/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: outlook-add-in-set-signature
 products:
 - office-outlook
 - office

--- a/Samples/outlook-tag-external/README.md
+++ b/Samples/outlook-tag-external/README.md
@@ -1,5 +1,6 @@
 ---
 page_type: sample
+urlFragment: outlook-add-in-tag-external-recipients
 products:
 - office-outlook
 - office


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                                |
| New feature?    | no                                |
| New sample?     | no                                |
| Related issues? | nonde |

## What's in this Pull Request?

This is an update to the sample code gallery metadata to provide each sample with a unique unchanging name (or URL in the gallery). Will prevent the gallery from using the H1 title of the readmes, which can change and then break a URL link in the code gallery. This ensure URLs are always the same even if you change the H1