### PR TITLE
Update DotNetCompilerPlatform in web.config

### DIFF
--- a/Samples/auth/Outlook-Add-in-SSO/AttachmentDemoWeb/Web.config
+++ b/Samples/auth/Outlook-Add-in-SSO/AttachmentDemoWeb/Web.config
@@ -77,8 +77,8 @@
   </system.webServer>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
 </configuration>


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | fixes #205       |

## What's in this Pull Request?

Still wasn't working properly due to the mismatched version of DotNetCompilerPlatform in web.config.
Ran "Update-Package Microsoft.CodeDom.Providers.DotNetCompilerPlatform -r" to update web.config.

## Guidance

Running "Update-Package Microsoft.CodeDom.Providers.DotNetCompilerPlatform -r" will do the exact same thing as this PR, changing the two lines in web.config. After this I was able to succesfully run tha sample on Outlook on the Web in Edge and Chrome as well as in the Office Client Application (Outlook Desktop).