### PR TITLE
Add ability to manually run audit-fix workflow

### DIFF
--- a/.github/workflows/autorun-npm-audit-fix.yml
+++ b/.github/workflows/autorun-npm-audit-fix.yml
@@ -3,6 +3,7 @@ run-name: Automatically run npm audit fix
 on:
   schedule:
     - cron: '45 08 15 * *' # Run at 1:45 AM PDT on the 15th of every month
+  workflow_dispatch:
 jobs:
   autorun-npm-audit-fix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | none |

## What's in this Pull Request?

Adds option to allow the npm-audit-fix workflow to be run manually.