### PR TITLE
fix: add sampleTag for M365 Agents Toolkit telemetry tracking

### DIFF
--- a/Samples/outlook-set-signature/m365agents.yml
+++ b/Samples/outlook-set-signature/m365agents.yml
@@ -3,6 +3,9 @@
 # Visit https://aka.ms/teamsfx-actions for details on actions
 version: 1.0.0
 
+additionalMetadata:
+  sampleTag: Office-Add-in-samples:outlook-add-in-set-signature
+
 environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed


### PR DESCRIPTION
## Summary

This PR adds \sampleTag\ to the \m365agents.yml\ file for telemetry tracking in M365 Agents Toolkit.

### Changes

**outlook-set-signature**
- Added \dditionalMetadata.sampleTag: Office-Add-in-samples:outlook-add-in-set-signature\

## Why is this needed?

The \sampleTag\ in \m365agents.yml\ is required for M365 Agents Toolkit to track sample usage telemetry. Without it, usage data cannot be properly attributed to this sample.

## Validation

The sample has been validated using the TeamsFx Sample Validator tool.