### PR TITLE
fix: update yml version to v1.2 to support additionalMetadata

### DIFF
--- a/Samples/outlook-set-signature/m365agents.yml
+++ b/Samples/outlook-set-signature/m365agents.yml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/teams-toolkit/1.0.0/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.2/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: 1.0.0
+version: v1.2
 
 additionalMetadata:
   sampleTag: Office-Add-in-samples:outlook-add-in-set-signature


### PR DESCRIPTION
## Summary
This PR updates the \m365agents.yml\ version from \1.0.0\ to \1.2\ to properly support the \dditionalMetadata\ field.

## Background
In PR #1081, we added \dditionalMetadata.sampleTag\ for telemetry tracking. However, the yml file version was \1.0.0\, which doesn't support the \dditionalMetadata\ field. The \dditionalMetadata\ feature was introduced in version \1.2\.

## Changes
- Updated schema URL from \1.0.0\ to \1.2\
- Updated version field from \1.0.0\ to \1.2\

## Related PR
- #1081 (Added sampleTag for telemetry tracking)